### PR TITLE
Add http_headers.include_deprecated option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+- `http_headers.include_deprecated` configuration option
+
 ## [0.0.0] - 2024-11-10
 
 Initial release

--- a/README.md
+++ b/README.md
@@ -63,6 +63,20 @@ markdown_extension:
         content-md5: "https://www.rfc-editor.org/rfc/rfc2616.html#section-14.15"
 ```
 
+I've bundled the registered HTTP headers from the [IANA HTTP Field Name Registry] in
+the CSV form. By default, the **permanent** headers are included. If you need to reference
+deprecated, obsolete, or provisional headers, then set `http_headers.include_deprecated`
+to `true`.
+
+```yaml
+markdown_extensions:
+  - ietflinks:
+    http_headers:
+      include_deprecated: true
+```
+
+[IANA HTTP Field Name Registry]: https://www.iana.org/assignments/http-fields/http-fields.xhtml
+
 You can also change the URL template if you find a reason to. It defaults to
 `https://www.rfc-editor.org/rfc/rfc{rfc}`. The `{rfc}` parameter is replaced by the
 RFC number.


### PR DESCRIPTION
I needed to reference `Accept-Charset` which was deprecated by https://www.rfc-editor.org/rfc/rfc9110.html#name-accept-charset